### PR TITLE
Synchronize @date-io DateType types

### DIFF
--- a/plugins/opencost/package.json
+++ b/plugins/opencost/package.json
@@ -25,7 +25,7 @@
     "@backstage/core-components": "workspace:^",
     "@backstage/core-plugin-api": "workspace:^",
     "@backstage/theme": "workspace:^",
-    "@date-io/date-fns": "^2.16.0",
+    "@date-io/luxon": "1.x",
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.60",

--- a/plugins/opencost/src/components/SelectWindow.jsx
+++ b/plugins/opencost/src/components/SelectWindow.jsx
@@ -16,13 +16,13 @@
 
 import React, { useEffect, useState } from 'react';
 import { makeStyles } from '@material-ui/styles';
-import { endOfDay, startOfDay } from 'date-fns';
+import { endOfDay, startOfDay } from '@date-io/luxon';
 import {
   MuiPickersUtilsProvider,
   KeyboardDatePicker,
 } from '@material-ui/pickers';
 import Button from '@material-ui/core/Button';
-import DateFnsUtils from '@date-io/date-fns';
+import LuxonUtils from '@date-io/luxon';
 import FormControl from '@material-ui/core/FormControl';
 import Link from '@material-ui/core/Link';
 import Popover from '@material-ui/core/Popover';
@@ -141,7 +141,7 @@ const SelectWindow = ({ windowOptions, window, setWindow }) => {
       >
         <div className={classes.dateContainer}>
           <div className={classes.dateContainerColumn}>
-            <MuiPickersUtilsProvider utils={DateFnsUtils}>
+            <MuiPickersUtilsProvider utils={LuxonUtils}>
               <KeyboardDatePicker
                 style={{ width: '144px' }}
                 autoOk


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This pull request includes a small tweak to the opencost plugin so that the TS types will build correctly.

In short, the issue arose because the opencost plugin was using date utils from `@date-io/date-fns`, while all other plugins in the package used `@date-io/luxon`. `date-fns` and `luxon` each export a `DateType` type, and they were conflicting when importing from `@date-io`. This change switches the opencost plugin to use `@date-io/luxon` like the other plugins, and resolves the type error.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
